### PR TITLE
core: implement first release improvements

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+coverage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,17 @@
 {
   "name": "@enzoferey/ethers-error-parser",
-  "version": "0.1.0",
+  "version": "0.1.1",
+  "license": "MIT",
+  "homepage": "https://github.com/enzoferey/ethers-error-parser",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/enzoferey/ethers-error-parser.git"
+  },
+  "keywords": [
+    "ethers-js",
+    "error",
+    "parsing"
+  ],
   "type": "module",
   "files": [
     "dist"
@@ -16,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && vite build",
-    "prepublish": "yarn build",
+    "prepublishOnly": "yarn build",
     "ts:check": "tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,11 +13,12 @@ export default defineConfig({
   },
   plugins: [dts()],
   test: {
+    mockReset: true,
     coverage: {
       src: ["lib"],
-      reporter: ["lcov"],
+      reporter: ["text", "lcov"],
       all: true,
-      exclude: ["lib/index.ts", "lib/types.ts"],
+      exclude: ["lib/**/index.ts", "lib/types.ts", "*.d.ts"],
       100: true,
     },
   },


### PR DESCRIPTION
- Prettier ignores `coverage` directory
- Fixes `prepublishOnly` hook
- Adds missing metadata to `package.json`
- Resets mock between each test
- Outputs test coverage in the console
- Makes test coverage exclude patterns more generic