### PR TITLE
feat: expose RETURN_VALUE_ERROR_CODES constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,6 @@ Here is the complete list of returned objects:
 | `MAX_FEE_PER_GAS_LESS_THAN_BLOCK_BASE_FEE`             | `undefined `                                                               |
 | `UNKNOWN_ERROR`                                        | Some code or description of the error if available. `undefined` otherwise. |
 
+The error codes strings can be accesses via the `RETURN_VALUE_ERROR_CODES` constant that the package exports.
+
 If you find some error that is not handled yet or that does not provide a great context, please open an issue or pull request 🙏

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,1 +1,2 @@
 export { getParsedEthersError } from "./getParsedEthersError";
+export { RETURN_VALUE_ERROR_CODES } from "./constants";


### PR DESCRIPTION
## Is your pull request closing an issue?

Closes https://github.com/enzoferey/ethers-error-parser/issues/33.

## Please explain the main changes of your pull request

Exports the `RETURN_VALUE_ERROR_CODES` constant so JavaScript users avoid typos and TypeScript users do not have to hardcode strings.